### PR TITLE
full support mzid 1.0 and 1.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Version 0.99.3
 --------------------------------------------------------------------------------
 * Fix for issue #6. It now correctly parses files with empty AnalysisData
   nodes as empty mzID objects.
+* Full support for mzIdentML v1.0 and v1.1 
 
 Version 0.99.2
 --------------------------------------------------------------------------------

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -254,3 +254,8 @@ getPath <- function(ns) {
     }
     return(path)
 }
+
+colNamesToLower <- function(x) {
+    colnames(x) <- casefold(colnames(x), upper=FALSE)
+    x
+}

--- a/R/mzID.R
+++ b/R/mzID.R
@@ -125,14 +125,14 @@ setMethod(
         flatEviData <- 
             cbind(object@evidence@evidence,
                   object@database@database[
-                      match(object@evidence@evidence$dBSequence_ref,
+                      match(object@evidence@evidence$dbsequence_ref,
                             object@database@database$id), ])
         flatEviData <- flatEviData[,!names(flatEviData) == 'id']
         flatPep <- flatten(object@peptides)
         flatPepEviData <- 
             merge( flatPep, flatEviData, 
                    by.x="id", by.y="peptide_ref", all=TRUE)
-        if(no.redundancy){
+        if (no.redundancy) {
             flatPepEviData <- 
                 flatPepEviData[!duplicated(flatPepEviData[,'id']),]
         }
@@ -140,11 +140,11 @@ setMethod(
                          by.x='peptide_ref', by.y='id', all=TRUE)
         flatAll$spectrumFile <- 
             object@parameters@rawFile$name[
-                match(flatAll$spectraData_ref,
+                match(flatAll$spectradata_ref,
                       object@parameters@rawFile$id)]
         flatAll$databaseFile <- 
             object@parameters@databaseFile$name[
-                match(flatAll$searchDatabase_ref,
+1                match(flatAll$searchdatabase_ref,
                       object@parameters@databaseFile$id)]
         flatAll <- flatAll[, !grepl('_ref$', 
                                     names(flatAll), 

--- a/R/mzIDdatabase.R
+++ b/R/mzIDdatabase.R
@@ -126,6 +126,7 @@ mzIDdatabase <- function(doc, ns){
             database$sequence <- NA
             database$sequence[hasSeq != 0] <- dbseq
         }
-        new(Class = 'mzIDdatabase', database =database)
+        new(Class = 'mzIDdatabase',
+            database = colNamesToLower(database))
     }
 }

--- a/R/mzIDevidence.R
+++ b/R/mzIDevidence.R
@@ -106,7 +106,11 @@ mzIDevidence <- function(doc, ns) {
         } else { ## "1.0"
             evidence <- attrExtract(doc, ns,
                                     paste0(.path, '/x:DataCollection/x:AnalysisData/x:SpectrumIdentificationList/x:SpectrumIdentificationResult/x:SpectrumIdentificationItem/x:PeptideEvidence'))
+            evidence$peptide_ref <-
+                sub("PE", "peptide",
+                    substr(evidence$id, 1, 6))
         }        
-        new(Class='mzIDevidence', evidence=evidence)
+        new(Class = 'mzIDevidence',
+            evidence = colNamesToLower(evidence))
     }
 }

--- a/R/mzIDpeptides.R
+++ b/R/mzIDpeptides.R
@@ -152,6 +152,8 @@ mzIDpeptides <- function(doc, ns) {
             pepDF <- data.frame(pepID, pepSeq, modified=FALSE, stringsAsFactors=FALSE)
             modList <- list()
         }
-        new(Class='mzIDpeptides', peptides=pepDF, modifications=modList)
+        new(Class='mzIDpeptides',
+            peptides=colNamesToLower(pepDF),
+            modifications=modList)
     }
 }

--- a/R/mzIDpsm.R
+++ b/R/mzIDpsm.R
@@ -142,6 +142,9 @@ mzIDpsm <-function(doc, ns) {
                                       "/x:DataCollection/x:AnalysisData/x:SpectrumIdentificationList/x:SpectrumIdentificationResult"), 'SpectrumIdentificationItem')
         indMap <- list()
         indMap[nID > 0] <- split(1:nrow(id), rep(1:length(nID), nID))
-        new(Class='mzIDpsm', scans=scans, id=id, mapping=indMap)
+        new(Class = 'mzIDpsm',
+            scans = colNamesToLower(scans),
+            id = colNamesToLower(id),
+            mapping = indMap)
     }
 }


### PR DESCRIPTION
Summary of changes:
- column names in all mzID slot data.frames (except database) have been set to lower case
- `object@evidence@evidence` has new column `peptide_ref`, created from `object@evidence@evidence$id`.
- fixed issue #8

Identity has been tested with loaded two identical searches exported to v1.0 and v1.1.
