### PR TITLE
create mzR compatible acquisitionNum column

### DIFF
--- a/R/mzIDpsm.R
+++ b/R/mzIDpsm.R
@@ -135,6 +135,10 @@ mzIDpsm <-function(doc, ns, addFinalizer=FALSE, path) {
     if (nrow(scans) == 0) {
         return(new("mzIDpsm"))
     }
+    
+    ## create mzR compatible acquisitionNum column
+    scans$acquisitionNum <- as.numeric(sub("^.*=([[:digit:]]+)$", "\\1", scans$spectrumID))
+
     id <- attrExtract(doc, ns,
                     path=paste0(.path, "/x:DataCollection/x:AnalysisData/x:SpectrumIdentificationList/x:SpectrumIdentificationResult/x:SpectrumIdentificationItem"),
                     addFinalizer=addFinalizer)


### PR DESCRIPTION
See you suggestion at: https://github.com/lgatto/msidmatching/issues/2#issuecomment-38152730

BTW it is not part of `flatten` but part of the `mzIDpsm` parser.
