### PR TITLE
add id filename to flatten output

### DIFF
--- a/R/mzID.R
+++ b/R/mzID.R
@@ -132,6 +132,7 @@ setMethod(
         flatAll <- cbind(flatPSM[rep(1:nrow(flatPSM), times=groupLength),], flatPepEviData[unlist(peptideGroups),])
 #         flatAll <- merge(flatPSM, flatPepEviData, 
 #                          by.x='peptide_ref', by.y='id', all=TRUE)
+        flatAll$idFile <- basename(object@parameters@idFile)
         flatAll$spectrumFile <- object@parameters@rawFile$name[match(safeCol(flatAll, 'spectradata_ref'), object@parameters@rawFile$id)]
         flatAll$databaseFile <- object@parameters@databaseFile$name[match(safeCol(flatAll, 'searchdatabase_ref'), object@parameters@databaseFile$id)]
         flatAll <- flatAll[, !grepl('_ref$', tolower(names(flatAll)), perl=T) & !tolower(names(flatAll)) == 'id']


### PR DESCRIPTION
Dear Thomas,

this PR adds the filename of the identification file to the output of `flatten`. Currently only the spectrum and database file are present. For some statistics, e.g. coverage we need the origin of each row in the flattened `data.frame` in `MSnbase` (that' why `files(mzIDCollection)` is not enough).

Best wishes,

Sebastian

CC: @lgatto 