### PR TITLE
use "location" instead of the "name" attribute

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mzID
 Type: Package
 Title: An mzIdentML parser for R
-Version: 1.5.2
-Date: 2015-01-27
+Version: 1.5.3
+Date: 2015-04-03
 Author: Thomas Lin Pedersen, Vladislav A Petyuk with contributions from
     Laurent Gatto and Sebastian Gibb.
 Maintainer: Thomas Lin Pedersen <thomasp85@gmail.com>

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Version 1.5.3
+________________________________________________________________________________
+* Use "location" attribute instead of "name" to create the
+  spectrumFile/databaseFile column in the flattened data.frame.
+
 Version 1.3.6
 ________________________________________________________________________________
 * Huge restructuring in documentation

--- a/R/mzID.R
+++ b/R/mzID.R
@@ -135,7 +135,7 @@ setMethod(
 #                          by.x='peptide_ref', by.y='id', all=TRUE)
         flatAll$idFile <- basename(object@parameters@idFile)
         flatAll$spectrumFile <- basename(object@parameters@rawFile$location[match(safeCol(flatAll, 'spectradata_ref'), object@parameters@rawFile$id)])
-        flatAll$databaseFile <- object@parameters@databaseFile$name[match(safeCol(flatAll, 'searchdatabase_ref'), object@parameters@databaseFile$id)]
+        flatAll$databaseFile <- basename(object@parameters@databaseFile$location[match(safeCol(flatAll, 'searchdatabase_ref'), object@parameters@databaseFile$id)])
         flatAll <- flatAll[, !grepl('_ref$', tolower(names(flatAll)), perl=T) & !tolower(names(flatAll)) == 'id']
         return(flatAll)
     }

--- a/R/mzID.R
+++ b/R/mzID.R
@@ -134,7 +134,7 @@ setMethod(
 #         flatAll <- merge(flatPSM, flatPepEviData, 
 #                          by.x='peptide_ref', by.y='id', all=TRUE)
         flatAll$idFile <- basename(object@parameters@idFile)
-        flatAll$spectrumFile <- object@parameters@rawFile$name[match(safeCol(flatAll, 'spectradata_ref'), object@parameters@rawFile$id)]
+        flatAll$spectrumFile <- basename(object@parameters@rawFile$location[match(safeCol(flatAll, 'spectradata_ref'), object@parameters@rawFile$id)])
         flatAll$databaseFile <- object@parameters@databaseFile$name[match(safeCol(flatAll, 'searchdatabase_ref'), object@parameters@databaseFile$id)]
         flatAll <- flatAll[, !grepl('_ref$', tolower(names(flatAll)), perl=T) & !tolower(names(flatAll)) == 'id']
         return(flatAll)


### PR DESCRIPTION
Dear Thomas,

this PR changes the creation of the `spectrumFile` and `databaseFile` column in the flattened `data.frame`. Before you used the `SpectraData@name` and `SearchDatabase@name` to create these columns. According to the [mzIdentML specification (section 6.70, 6.60)](http://www.psidev.info/sites/default/files/mzIdentML1.1.0.pdf) the `name` attribute is _optional_. A user send me a mzIdentML file generated using "Scaffold" that doesn't have the `name` attribute and causes errors in `MSnbase::addIdentificationData`.
I now use the `location` attribute that mostly contains the same information as before but is _required_ and should be present in all mzIdentML files.

Best wishes,

Sebastian
